### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -131,6 +131,7 @@ export default function DashboardSidebar({
           onClick={() => window.open('/', '_blank')}
           className="flex items-center gap-3 px-3 py-2 rounded-xl text-slate-400 hover:text-slate-600 hover:bg-white/40 transition-all text-sm"
           title="Kembali ke Website"
+          aria-label="Kembali ke Website"
         >
           <ExternalLink size={18} />
           {!collapsed && <span>Website Utama</span>}
@@ -139,6 +140,7 @@ export default function DashboardSidebar({
           onClick={onToggleCollapse}
           className="flex items-center gap-3 px-3 py-2 rounded-xl text-slate-400 hover:text-slate-600 hover:bg-white/40 transition-all text-sm"
           title={collapsed ? 'Perluas Sidebar' : 'Perkecil Sidebar'}
+          aria-label={collapsed ? 'Perluas Sidebar' : 'Perkecil Sidebar'}
         >
           {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}
           {!collapsed && <span>Perkecil</span>}

--- a/src/components/dashboard/FloatingChatBot.tsx
+++ b/src/components/dashboard/FloatingChatBot.tsx
@@ -621,12 +621,15 @@ export default function FloatingChatBot() {
                     : 'text-slate-300 hover:bg-white/60'
                 )}
                 title={chatEnabled ? 'Nonaktifkan Chatbot' : 'Aktifkan Chatbot'}
+                aria-label={chatEnabled ? 'Nonaktifkan Chatbot' : 'Aktifkan Chatbot'}
               >
                 {chatEnabled ? <Power size={14} /> : <PowerOff size={14} />}
               </button>
               <button
                 onClick={() => setIsOpen(false)}
                 className="p-1.5 rounded-lg text-slate-400 hover:text-slate-800 hover:bg-white/60 transition-all"
+                title="Tutup Chat"
+                aria-label="Tutup Chat"
               >
                 <X size={16} />
               </button>
@@ -781,6 +784,7 @@ export default function FloatingChatBot() {
                     : 'text-slate-400 hover:text-slate-500 hover:bg-white/50'
                 )}
                 title={isRecording ? 'Berhenti merekam' : 'Input suara'}
+                aria-label={isRecording ? 'Berhenti merekam' : 'Input suara'}
               >
                 {isRecording ? <MicOff size={16} /> : <Mic size={16} />}
               </button>
@@ -791,6 +795,7 @@ export default function FloatingChatBot() {
                   text-cyan-600 hover:from-cyan-200/60 hover:to-blue-200/60 
                   transition-all disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
                 title="Kirim"
+                aria-label="Kirim pesan"
               >
                 <Send size={16} />
               </button>

--- a/src/components/dashboard/NotificationPopup.tsx
+++ b/src/components/dashboard/NotificationPopup.tsx
@@ -201,6 +201,7 @@ function PopupCard({
                 onClick={onDismiss}
                 className="p-1 rounded-lg text-slate-400 hover:text-slate-800 hover:bg-white/60 transition-all flex-shrink-0"
                 title="Tutup"
+                aria-label="Tutup notifikasi"
               >
                 <X size={14} />
               </button>
@@ -282,6 +283,7 @@ function PopupCard({
                 disabled={!replyText.trim() || replyLoading}
                 className="p-1.5 rounded-lg bg-cyan-100/80 text-cyan-600 hover:bg-cyan-500/30 transition-all disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
                 title="Kirim balasan"
+                aria-label="Kirim balasan"
               >
                 {replyLoading ? (
                   <Loader2 size={12} className="animate-spin" />

--- a/src/components/dashboard/NotificationProvider.tsx
+++ b/src/components/dashboard/NotificationProvider.tsx
@@ -180,7 +180,11 @@ export function NotificationProvider({
   const toggleBeepMuted = useCallback(() => {
     setBeepMuted((prev) => {
       const next = !prev;
-      try { localStorage.setItem('ywm_beep_muted', String(next)); } catch {}
+      try {
+        localStorage.setItem('ywm_beep_muted', String(next));
+      } catch (err) {
+        if (import.meta.env.DEV) console.error('Failed to save beep muted state:', err);
+      }
       return next;
     });
   }, []);

--- a/src/components/dashboard/modules/SparePartsModule.tsx
+++ b/src/components/dashboard/modules/SparePartsModule.tsx
@@ -295,10 +295,20 @@ export default function SparePartsModule() {
                     <td className="px-4 py-3 text-slate-500">{item.pemasok}</td>
                     <td className="px-4 py-3 text-right">
                       <div className="flex items-center justify-end gap-1">
-                        <button onClick={() => handleEdit(item)} className="p-1.5 rounded-lg hover:bg-white/50 text-slate-400 hover:text-cyan-600 transition-all" title="Edit">
+                        <button
+                          onClick={() => handleEdit(item)}
+                          className="p-1.5 rounded-lg hover:bg-white/50 text-slate-400 hover:text-cyan-600 transition-all"
+                          title="Edit"
+                          aria-label="Edit suku cadang"
+                        >
                           <Edit2 size={14} />
                         </button>
-                        <button onClick={() => setDeleteConfirm(item.id)} className="p-1.5 rounded-lg hover:bg-white/50 text-slate-400 hover:text-red-600 transition-all" title="Hapus">
+                        <button
+                          onClick={() => setDeleteConfirm(item.id)}
+                          className="p-1.5 rounded-lg hover:bg-white/50 text-slate-400 hover:text-red-600 transition-all"
+                          title="Hapus"
+                          aria-label="Hapus suku cadang"
+                        >
                           <Trash2 size={14} />
                         </button>
                       </div>


### PR DESCRIPTION
💡 What: This PR adds ARIA labels to several icon-only buttons across the YWM Dashboard.

🎯 Why: Icon-only buttons currently lack descriptive labels for screen readers, which is an accessibility barrier. Adding `aria-label` attributes ensures these interactive elements are intuitive for all users.

♿ Accessibility:
- Added `aria-label` to "Edit" and "Hapus" buttons in the Spare Parts table.
- Added `aria-label` and `title` to AI Chatbot controls (Power toggle, Close, Mic, and Send).
- Added `aria-label` to Notification controls.
- Added `aria-label` to Sidebar navigation and toggle buttons.

🔧 Technical:
- Fixed one pre-existing ESLint 'no-empty' block error in `NotificationProvider.tsx` discovered during verification.
- Verified changes with `npm run lint` and `npm run build`.
- Verified UI changes using Playwright screenshots.

---
*PR created automatically by Jules for task [17077571437878112134](https://jules.google.com/task/17077571437878112134) started by @mulkymalikuldhrs*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced accessibility support by adding descriptive labels to buttons in the sidebar, floating chat, notifications, and spare parts action controls
  * Improved reliability of notification mute state persistence with enhanced error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->